### PR TITLE
Change to gulp tidy

### DIFF
--- a/gulp-tasks/scss-tidy.js
+++ b/gulp-tasks/scss-tidy.js
@@ -4,7 +4,6 @@ module.exports = function(gulp, plugins, config) {
 		return gulp.src(config.paths.input.styles)
 			.pipe(plugins.postcss([
 				plugins.postcssSorting({ 'properties-order': 'alphabetical' })
-			], { syntax: plugins.postcssScss }))
-			.pipe(gulp.dest('src/sass'));
+			], { syntax: plugins.postcssScss }));
 	});
 };


### PR DESCRIPTION
When I was running the build task, the line I've removed was causing an scss folder to be created in both dist and src, and for all the scss to be copied into it.

This wasn't needed in either case.