### PR TITLE
Browser sync and watch changes.

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
 			"stylesFolder": "src/styles",
 			"spriteSrc": "src/images/sprite-src",
 			"html": ["src/**/*.html", "!src/includes/**/*.html"],
+			"htmlWatch": ["src/**/*.html"],
 			"images": "src/images/**/*",
 			"staticDev": ["src/**/*", "!src/**/*.html", "!src/scripts/**/*", "!src/styles/**/*"],
 			"staticBuild": ["src/**/*", "!src/**/*.html", "!src/scripts/**/*", "!src/styles/**/*", "!src/images/**/*"],

--- a/gulp-tasks/browser-sync.js
+++ b/gulp-tasks/browser-sync.js
@@ -23,4 +23,9 @@ module.exports = function(gulp, plugins, config) {
 			});
 		}
 	});
+
+	gulp.task('browser-reload', function() {
+		//watch files
+		plugins.browserSync.reload();
+	});
 };

--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -5,6 +5,8 @@ module.exports = function(gulp, plugins, config) {
 		gulp.watch(config.paths.input.spriteSrc, ['sprite-create']);
 		gulp.watch(config.paths.input.images + '**/*.svg', ['svg2png']);
 		gulp.watch(config.paths.input.scripts + '**/*.js', ['babelify-develop']);
-		gulp.watch(config.paths.input.html, ['html-templating-develop']);
+		gulp.watch(config.paths.input.htmlWatch, function () {
+			plugins.runSequence('html-templating-develop', 'browser-reload');
+		});
 	});
 };


### PR DESCRIPTION
Added a htmlWatch config option, so that the watch task will watch template as well as main html files. 

Added a browser reload task to the browser-sync gulp file.  

Updated Watch task to use the new htmlWatch path, and to call the new browser reload task AFTER the html templating task has been completed.  

This was because the built in browser sync watch was triggering a reload as soon as one file had changed rather than at the end of the template build task. 