### PR TITLE
David release folder

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,8 @@
 			"images": "dist/images",
 			"scripts": "dist/scripts",
 			"styles": "dist/styles",
-			"html": "dist/**/*.html"
+			"html": "dist/**/*.html",
+			"release": "release/"
 		}
 	},
 	"browserSync": {

--- a/gulp-tasks/clean-release.js
+++ b/gulp-tasks/clean-release.js
@@ -1,0 +1,8 @@
+module.exports = function (gulp, plugins, config, errorHandler) {
+	gulp.task('clean-release', function() {
+		//clean all files
+		return gulp
+			.src(config.paths.output.release)
+			.pipe(plugins.clean());
+	});
+};

--- a/gulp-tasks/copy-release.js
+++ b/gulp-tasks/copy-release.js
@@ -1,0 +1,8 @@
+module.exports = function (gulp, plugins, config, errorHandler) {
+    gulp.task('copy-release', function() {
+        //copy all files
+		gulp.src(config.paths.output.devRoot + '/**/*', { nodir: true })
+        .pipe(plugins.plumber(errorHandler))
+        .pipe(gulp.dest(config.paths.output.release));
+    });
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,10 +8,12 @@ var errorHandler = require('./gulp-tasks/error')(plugins, config);
 
 // Clean
 require('./gulp-tasks/clean')(gulp, plugins, config, errorHandler);
+require('./gulp-tasks/clean-release')(gulp, plugins, config, errorHandler);
 
 // Copy
 require('./gulp-tasks/copy-dev')(gulp, plugins, config, errorHandler);
 require('./gulp-tasks/copy-build')(gulp, plugins, config, errorHandler);
+require('./gulp-tasks/copy-release')(gulp, plugins, config, errorHandler);
 
 // SCSS
 require('./gulp-tasks/scss-lint')(gulp, plugins, config, errorHandler);
@@ -53,5 +55,8 @@ gulp.task('build', function(callback) {
 	plugins.runSequence('clean', 'copy-build', ['image-min', 'sass-build', 'babelify-build', 'es-lint', 'html-templating-build'], 'complete', callback);
 });
 
+gulp.task('release', function(callback) {
+	plugins.runSequence('clean-release', 'copy-release', 'complete', callback);
+});
 
 gulp.task('default', ['develop']);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-boilerplate",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "",
   "author": "Realise",
   "devDependencies": {


### PR DESCRIPTION
Addresses #66 

Have added a new /release folder in the project - this is where "production ready" code should go for deployment.

There is also a new "gulp release" workflow which will clear out /release (including that temporary text file) and then copy in the contents of /dist ("gulp build" needs to be run before hand).