### PR TITLE
Making data available globally via a filter

### DIFF
--- a/gulp-tasks/html-templating.js
+++ b/gulp-tasks/html-templating.js
@@ -14,6 +14,7 @@ module.exports = function (gulp, plugins, config, errorHandler) {
 
 	gulp.task('merge-data', function (callback) {
 		gulp.src(config.paths.input.data)
+			.pipe(plugins.plumber(errorHandler))
 			.pipe(plugins.mergeJson({
 				endObj: {
 					'context': {
@@ -27,7 +28,14 @@ module.exports = function (gulp, plugins, config, errorHandler) {
 
 	gulp.task('compile-handlebars', function () {
 		gulp.src(config.paths.input.html)
-			.pipe(plugins.nunjucks.compile(combined))
+			.pipe(plugins.plumber(errorHandler))
+			.pipe(plugins.nunjucks.compile(combined, {
+				filters: {
+					'getGlobal': function(str) {
+						return combined;
+					}
+				}
+			}))
 			.pipe(gulp.dest(config.paths.output.devRoot));
 	});
 };

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -7,7 +7,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="apple-touch-icon" href="icon.png">
 
-		{% if content.task === 'build' %}
+		{% if ('' | getGlobal).context.task === 'build' %}
 			<link rel="stylesheet" type="text/css" href="styles/main.min.css" media="screen">
 		{% else %}
 			<link rel="stylesheet" type="text/css" href="styles/main.css" media="screen">
@@ -18,7 +18,7 @@
 
 		{% include "./includes/footer.html" %}
 
-		{% if content.task === 'build' %}
+		{% if ('' | getGlobal).context.task === 'build' %}
 			<script src="scripts/main.min.js"></script>
 		{% else %}
 			<script src="scripts/main.js"></script>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -7,7 +7,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="apple-touch-icon" href="icon.png">
 
-		{% if content.task === 'build' %}
+		{% if ('' | getGlobal).context.task === 'build' %}
 			<link rel="stylesheet" type="text/css" href="styles/main.min.css" media="screen">
 		{% else %}
 			<link rel="stylesheet" type="text/css" href="styles/main.css" media="screen">
@@ -28,7 +28,7 @@
 
 		{% include "./includes/footer.html" %}
 
-		{% if content.task === 'build' %}
+		{% if ('' | getGlobal).context.task === 'build' %}
 			<script src="scripts/main.min.js"></script>
 		{% else %}
 			<script src="scripts/main.js"></script>


### PR DESCRIPTION
This is dirty, but currently the only way I could find of achieving this.

In Nunjucks, you can't have variables available globally (well you can sort of, but doesn't seem to be immediately obvious how you achieve this when using Gulp), meaning you constantly have to pass variables between mixins. This of course is fine of most of the time, but there are occasions when it's a pain - for example checking whether we're running the "develop" or "build" task, which has caused multiple people to be confused when the generated HTML hasn't ended up pointing at main.min.css and main.min.js

To work around this I have added a custom filter (you don't seem to be able to add functions and variables from Gulp) which will return _all_ of the JSON we're passing into Nunjucks. Meaning you can access it anywhere by calling:

`'' | getGlobal`

This is obviously a bastardisation of filters - doesn't matter you pass into the filter, it will always return the main JSON data.

So for example you could then do:

`('' | getGlobal).common.title`

Once this is merged in I'll document in the wiki.